### PR TITLE
feat: re-export cx helper

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,14 @@ import type {
   ClassValue,
 } from "class-variance-authority"
 
-export { VariantProps, ClassProp, VariantsSchema, VariantsConfig, ClassValue }
+export { 
+  VariantProps, 
+  ClassProp, 
+  VariantsSchema, 
+  VariantsConfig, 
+  ClassValue, 
+  cx 
+}
 
 export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements
 


### PR DESCRIPTION
Can be useful as this eliminates the need of an explicit `clsx` dependency